### PR TITLE
Explicitly use MODE_ECB as default decryption mode

### DIFF
--- a/RATDecoders/malwareconfig/crypto.py
+++ b/RATDecoders/malwareconfig/crypto.py
@@ -45,13 +45,13 @@ def decrypt_des_cbc(key, data, iv=None):
 
 # DES3
 def decrypt_des3(key, data):
-    cipher = DES3.new(key)
+    cipher = DES3.new(key, DES3.MODE_ECB)
     return cipher.decrypt(data)
 
 
 # AES
 def decrypt_aes(key, data):
-    cipher = AES.new(key)
+    cipher = AES.new(key, AES.MODE_ECB)
     return cipher.decrypt(data)
 
 
@@ -63,7 +63,7 @@ def decrypt_aes_cbc_iv(key, iv, data):
 
 # Blowfish
 def decrypt_blowfish(key, data):
-    cipher = Blowfish.new(key)
+    cipher = Blowfish.new(key, Blowfish.MODE_ECB)
     return cipher.decrypt(data)
 
 


### PR DESCRIPTION
PyCryptodome no longer uses MODE_ECB as the default cipher mode.
MODE_ECB now must be passed in explicitly.
See https://github.com/Legrandin/pycryptodome/commit/465d0391ac4a821f3be032178fa2c9169afee593?branch=465d0391ac4a821f3be032178fa2c9169afee593