### PR TITLE
Fix report

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -220,12 +220,12 @@ def validate_parser_config():
         raise Exception("Number of parsers in mwcp_parsers and parser_config.yml don't match")
 
 
-def run(parser_list: List[str], f_path: str, report):
+def run(parser_list: List[str], f_path: str):
     # all parsers in this list already matched
     # all parsers to be run must be in yml file in parser_dir
     outputs = {}
     for parser in parser_list:
-        mwcp.run(parser, file_path=f_path)
+        report = mwcp.run(parser, file_path=f_path)
         if report.metadata:
             outputs[parser] = report.metadata
     if __name__ == '__main__':
@@ -636,7 +636,7 @@ def main(file_path, debug, verbose) -> None:
     file_pars, tag_pars = compile()
     parsers = deduplicate(file_pars, tag_pars, file_path)
     # for each parser entry check if match exists, if so run all parsers in parser_list for that entry
-    run(parsers, file_path, report)
+    run(parsers, file_path)
     print(report.as_text())
 
     # but can't run parsers until final list of parsers to run, from tag and file parsers is finished

--- a/configextractor.py
+++ b/configextractor.py
@@ -102,7 +102,7 @@ class ConfigExtractor(ServiceBase):
         # get matches for both, dedup then run
         cli.run_mwcfg(request.file_path, self.mwcp_report)
         parsers = cli.deduplicate(self.file_parsers, self.tag_parsers, request.file_path, newtags)
-        output_fields = cli.run(parsers, request.file_path, self.mwcp_report)
+        output_fields = cli.run(parsers, request.file_path)
 
 
         for parser, field_dict in output_fields.items():

--- a/configextractor.py
+++ b/configextractor.py
@@ -155,7 +155,7 @@ class ConfigExtractor(ServiceBase):
         if len(field_dict) > 0:  # if any decoder output exists raise heuristic
             parser_section.set_body(json.dumps(json_body), body_format=BODY_FORMAT.KEY_VALUE)
             parser_section.set_heuristic(HEURISTICS_MAP.get(category, 1), attack_id=mitre_att)
-            parser_section.add_tag("source", parsertype)
+            parser_section.add_tag("source", f"{parsertype}.{parser}")
 
             if malware_name:
                 parser_section.add_tag('attribution.implant', malware_name.upper())

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -628,8 +628,7 @@ class TestCLI:
             if correct_report.metadata:
                 correct_outputs[parser] = correct_report.metadata
 
-        test_report = get_report()
-        test_outputs = run(correct_file_parsers, f_path, test_report)
+        test_outputs = run(correct_file_parsers, f_path)
         assert test_outputs == correct_outputs
 
     @staticmethod


### PR DESCRIPTION
MWCP Report object was being shadowed by the report passed in, causing fields to be overwritten