### PR TITLE
Fix security issues, bugs, and hardening

### DIFF
--- a/configextractor_/configextractor_.py
+++ b/configextractor_/configextractor_.py
@@ -326,7 +326,7 @@ class ConfigExtractor(ServiceBase):
 
         # Skip excessively large files to avoid OOM in the container
         max_file_size = self.config.get("max_file_size", DEFAULT_MAX_SAMPLE_SIZE)
-        sample_size = os.path.getsize(request.file_path)
+        sample_size = request.task.file_size
         if sample_size > max_file_size:
             self.log.warning(
                 f"Sample size ({sample_size} bytes) exceeds limit ({max_file_size} bytes), skipping"

--- a/configextractor_/configextractor_.py
+++ b/configextractor_/configextractor_.py
@@ -44,6 +44,8 @@ cl_engine = forge.get_classification()
 
 CONNECTION_USAGE = [k.name for k in ConnUsageEnum]
 UPDATES_CHUNK_SIZE = int(os.environ.get("UPDATES_CHUNK_SIZE", "1024"))
+MAX_DOWNLOAD_RETRIES = 20
+DEFAULT_MAX_SAMPLE_SIZE = 256 * 1024 * 1024  # 256 MB
 
 
 class Base64TruncatedEncoder(json.JSONEncoder):
@@ -90,7 +92,7 @@ class ConfigExtractor(ServiceBase):
 
             # Check if there are new signatures
             retries = 0
-            while True:
+            while retries < MAX_DOWNLOAD_RETRIES:
                 resp = session.get(url_base + "status")
                 resp.raise_for_status()
                 status = resp.json()
@@ -107,6 +109,9 @@ class ConfigExtractor(ServiceBase):
                 self.log.warning("Waiting on update server availability...")
                 time.sleep(min(5**retries, 30))
                 retries += 1
+            else:
+                self.log.error(f"Update server not available after {MAX_DOWNLOAD_RETRIES} retries, giving up.")
+                return
 
             if os.path.exists(SERVICE_READY_PATH):
                 # Mark the service as not ready while updating rules
@@ -188,26 +193,30 @@ class ConfigExtractor(ServiceBase):
                     self.log.info(f"Removing temp directory: {temp_directory}")
                     shutil.rmtree(temp_directory, ignore_errors=True)
 
-            with open(SERVICE_READY_PATH, "w"):
-                # Mark the service as ready again
-                self.log.info("Service is marked as ready after updating rules.")
-                pass
+                # Always restore SERVICE_READY_PATH, even if an exception occurred
+                with open(SERVICE_READY_PATH, "w"):
+                    self.log.info("Service is marked as ready after updating rules.")
+                    pass
 
     # Generate the rules_hash and init rules_list based on the raw files in the rules_directory from updater
     def _gen_rules_hash(self) -> str:
         self.rules_list = []
         signatures_meta_path = os.path.join(self.rules_directory, SIGNATURES_META_FILENAME)
-        self.signatures_meta = json.loads(open(signatures_meta_path, "r").read())
+        with open(signatures_meta_path, "r") as f:
+            self.signatures_meta = json.loads(f.read())
         for obj in os.listdir(self.rules_directory):
             obj_path = os.path.join(self.rules_directory, obj)
             if obj_path != signatures_meta_path:
                 self.rules_list.append(obj_path)
-        all_sha256s = [f for f in self.rules_list]
+        all_paths = [f for f in self.rules_list]
 
-        if len(all_sha256s) == 1:
-            return all_sha256s[0][:7]
+        if len(all_paths) == 1:
+            return all_paths[0][:7]
 
-        return hashlib.sha256(" ".join(sorted(all_sha256s)).encode("utf-8")).hexdigest()[:7]
+        return hashlib.sha256(" ".join(sorted(all_paths)).encode("utf-8")).hexdigest()[:7]
+
+    def _clear_rules(self) -> None:
+        self.cx = None
 
     def _load_rules(self) -> None:
         if self.rules_list:
@@ -297,6 +306,8 @@ class ConfigExtractor(ServiceBase):
                     if isinstance(v, dict):
                         clean_config[k] = strip_null(v)
                     elif isinstance(v, list):
+                        if not v:
+                            continue
                         if isinstance(v[0], dict):
                             clean_config[k] = [strip_null(vi) for vi in v]
                         elif isinstance(v[0], str):
@@ -310,6 +321,17 @@ class ConfigExtractor(ServiceBase):
 
     def execute(self, request):
         result = Result()
+
+        # Skip excessively large files to avoid OOM in the container
+        max_file_size = self.config.get("max_file_size", DEFAULT_MAX_SAMPLE_SIZE)
+        sample_size = os.path.getsize(request.file_path)
+        if sample_size > max_file_size:
+            self.log.warning(
+                f"Sample size ({sample_size} bytes) exceeds limit ({max_file_size} bytes), skipping"
+            )
+            request.result = result
+            return
+
         config_result = self.cx.run_parsers(
             request.file_path,
             # Give 30s of leeway for the service to finish processing
@@ -319,19 +341,24 @@ class ConfigExtractor(ServiceBase):
             request.result = result
             return
 
-        a = tempfile.NamedTemporaryFile(delete=False)
-        a.write(json.dumps(config_result, cls=Base64Encoder).encode())
-        a.seek(0)
-        request.add_supplementary(
-            a.name,
-            f"{request.sha256}_malware_config.json",
-            "Raw output from configextractor-py",
-        )
+        tmp_supplementary = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            tmp_supplementary.write(json.dumps(config_result, cls=Base64Encoder).encode())
+            tmp_supplementary.close()
+            request.add_supplementary(
+                tmp_supplementary.name,
+                f"{request.sha256}_malware_config.json",
+                "Raw output from configextractor-py",
+            )
+        except Exception:
+            tmp_supplementary.close()
+            os.unlink(tmp_supplementary.name)
+            raise
         for parser_framework, parser_results in config_result.items():
             for parser_output in parser_results:
                 # Retrieve identifier from the results
-                id = parser_output.pop("id", None)
-                extractor_mod = self.cx.parsers[id]
+                parser_id = parser_output.pop("id", None)
+                extractor_mod = self.cx.parsers[parser_id]
                 extractor_details = self.cx.get_details(extractor_mod)
 
                 # For MACO >= 1.2.19, the `result_sharing` attribute should be used to classify the results
@@ -341,8 +368,8 @@ class ConfigExtractor(ServiceBase):
                     # For other frameworks, use the general `classification` attribute
                     classification = extractor_details["classification"]
 
-                if id not in self.signatures_meta:
-                    self.log.warning(f"{id} wasn't found in signatures map. Skipping...")
+                if parser_id not in self.signatures_meta:
+                    self.log.warning(f"{parser_id} wasn't found in signatures map. Skipping...")
                     continue
 
                 # Get AL-specific details about the parser
@@ -449,14 +476,19 @@ class ConfigExtractor(ServiceBase):
                         if isinstance(data, str):
                             data = data.encode()
                         sha256 = hashlib.sha256(data).hexdigest()
-                        a = tempfile.NamedTemporaryFile(delete=False)
-                        a.write(data)
-                        a.close()
-                        request.add_extracted(
-                            a.name,
-                            f"binary_{datatype}_{sha256}",
-                            "Extracted binary file",
-                        )
+                        tmp_binary = tempfile.NamedTemporaryFile(delete=False)
+                        try:
+                            tmp_binary.write(data)
+                            tmp_binary.close()
+                            request.add_extracted(
+                                tmp_binary.name,
+                                f"binary_{datatype}_{sha256}",
+                                "Extracted binary file",
+                            )
+                        except Exception:
+                            tmp_binary.close()
+                            os.unlink(tmp_binary.name)
+                            raise
 
                 if config:
                     other_tags = {}

--- a/configextractor_/maco_tags.py
+++ b/configextractor_/maco_tags.py
@@ -43,7 +43,7 @@ def extract_SMTP_tags(data: List[Dict]) -> Dict:
         if d.get("mail_from"):
             tags.setdefault("network.email.address", []).append(d["mail_from"])
         if d.get("subject"):
-            tags.setdefault("network.email.subject", []).append(d["mail_from"])
+            tags.setdefault("network.email.subject", []).append(d["subject"])
 
     return tags
 
@@ -132,7 +132,10 @@ def extract_connection_tags(data: List[Dict]) -> Dict:
 
 
 # Catch-all function for tagging strings
-def tag_output(output: Any, tags: dict = {}):
+def tag_output(output: Any, tags: dict = None):
+    if tags is None:
+        tags = {}
+
     def tag_string(value):
         if re.search(IP_ONLY_REGEX, value):
             tags.setdefault("network.static.ip", []).append(value)

--- a/configextractor_/update_server.py
+++ b/configextractor_/update_server.py
@@ -1,3 +1,4 @@
+import glob
 import json
 import os
 import shutil
@@ -51,10 +52,12 @@ class CXUpdateServer(ServiceUpdater):
         files_sha256,
         source_name,
         default_classification=Classification.UNRESTRICTED,
-        configuration={},
+        configuration=None,
         *args,
         **kwargs,
     ):
+        if configuration is None:
+            configuration = {}
         extractors_found = False
 
         # If there is a configuration to set the deployment status of the extractor, map it out
@@ -114,7 +117,11 @@ class CXUpdateServer(ServiceUpdater):
             cx = ConfigExtractor(parsers_dirs=[dir], logger=self.log, create_venv=True)
 
             # Cleanup uv-related lock files from the directory
-            subprocess.check_call(["rm", "-f", "/tmp/uv-*.lock"])
+            for lock_file in glob.glob("/tmp/uv-*.lock"):
+                try:
+                    os.unlink(lock_file)
+                except OSError:
+                    pass
 
             if cx.parsers:
                 extractors_found = True
@@ -266,6 +273,9 @@ class CXUpdateServer(ServiceUpdater):
             # Write the new status file
             temp_status = tempfile.NamedTemporaryFile("w+", delete=False, dir="/tmp")
             json.dump(self.status(), temp_status.file)
+            temp_status.file.flush()
+            os.fsync(temp_status.file.fileno())
+            temp_status.close()
             os.rename(temp_status.name, STATUS_FILE)
 
             self.log.info(f"Now serving: {self._update_dir} and {self._update_tar} ({self.get_local_update_time()})")

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -23,6 +23,10 @@ enabled: true
 privileged: true
 uses_temp_submission_data: true
 
+config:
+  # Maximum file size (in bytes) to process. Files larger than this are skipped.
+  max_file_size: 268435456
+
 submission_params:
   - default: true
     name: include_empty_config


### PR DESCRIPTION
configextractor_.py:
- Cap _download_rules() retry loop at MAX_DOWNLOAD_RETRIES (20)
- Override _clear_rules() to reset self.cx to None
- Move SERVICE_READY_PATH restoration into finally block
- Add MAX_SAMPLE_SIZE (256MB) guard in execute() to prevent OOM
- Fix temp file leak on supplementary JSON write
- Fix temp file leak on extracted binary write
- Fix IndexError on empty list in strip_null
- Rename misleading all_sha256s to all_paths
- Fix file handle leak in _gen_rules_hash (use with statement)
- Rename id to parser_id to avoid shadowing builtin

update_server.py:
- Replace no-op subprocess rm glob with glob.glob()
- Fix mutable default configuration={} to None
- Flush and fsync temp_status before os.rename

maco_tags.py:
- Fix SMTP subject tagged as mail_from
- Fix mutable default tags={} to None